### PR TITLE
Fixes {locale}/{any} not reachable because of {any}

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,11 +86,11 @@ class RouteServiceProvider extends ServiceProvider
         // We'll need a router to register routes duh.
         $router = $this->app->make(Router::class);
         
-        // We need our class the determine the right regex for the where statement
+        /** * @var Localize $localize */
         $localize = $this->app->make(Localize::class);
         
         // Okay so here is an IMPORTANT part.
-        // Register the {locale} routes first otherwise {locale}/{any} will not be reachable and {any} will catch it.
+        // Register the {locale} routes first otherwise {locale}/{any} will not be reachable and {any} will catch everything.
         $router->middleware('web')
             ->namespace($this->namespace)
             ->prefix('{' . $config->get('localize.route_parameter_key') . '}') // We add the prefix.

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ class RouteServiceProvider extends ServiceProvider
         // We'll need a router to register routes duh.
         $router = $this->app->make(Router::class);
         
-        /** * @var Localize $localize */
+        /** @var Localize $localize */
         $localize = $this->app->make(Localize::class);
         
         // Okay so here is an IMPORTANT part.

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ This makes it so that your default locale can use `/` instead of being forced to
 
 use Illuminate\Contracts\Config\Repository;
 use Illuminate\Routing\Router;
+use KingsCode\LaravelLocalize\Localize;
 
 class RouteServiceProvider extends ServiceProvider
 {
@@ -85,20 +86,20 @@ class RouteServiceProvider extends ServiceProvider
         // We'll need a router to register routes duh.
         $router = $this->app->make(Router::class);
         
+        // We need our class the determine the right regex for the where statement
+        $localize = $this->app->make(Localize::class);
+        
         // Okay so here is an IMPORTANT part.
-        // The normal routes, thus without prefix and prefixed name must be registered first.
-        // If this is not the case then the prefix is going to catch all your routes like `/pizza`
-        // Because `/{locale}` is registered before `/pizza`.
+        // Register the {locale} routes first otherwise {locale}/{any} will not be reachable and {any} will catch it.
         $router->middleware('web')
             ->namespace($this->namespace)
+            ->prefix('{' . $config->get('localize.route_parameter_key') . '}') // We add the prefix.
+            ->where([$config->get('localize.route_parameter_key') => $localize->getRouteRegex()])
+            ->name($config->get('localize.route_name_prefix') . '.') // And the name prefix.
             ->group(base_path('routes/localized.web.php'));
-
+        
         $router->middleware('web')
             ->namespace($this->namespace)
-            // We add the prefix.
-            ->prefix('{' . $config->get('localize.route_parameter_key') . '}')
-            // And the name prefix.
-            ->name($config->get('localize.route_name_prefix') . '.')
             ->group(base_path('routes/localized.web.php'));
     }
 }

--- a/README.md
+++ b/README.md
@@ -86,11 +86,14 @@ class RouteServiceProvider extends ServiceProvider
         // We'll need a router to register routes duh.
         $router = $this->app->make(Router::class);
         
-        // We need our class the determine the right regex for the where statement
+        /** 
+         *  Our helper class we gonna us this for getting our regex for the were statement
+         * @var Localize $localize 
+         */
         $localize = $this->app->make(Localize::class);
         
         // Okay so here is an IMPORTANT part.
-        // Register the {locale} routes first otherwise {locale}/{any} will not be reachable and {any} will catch it.
+        // Register the {locale} routes first otherwise {locale}/{any} will not be reachable and {any} will catch everything.
         $router->middleware('web')
             ->namespace($this->namespace)
             ->prefix('{' . $config->get('localize.route_parameter_key') . '}') // We add the prefix.

--- a/config/localize.php
+++ b/config/localize.php
@@ -28,5 +28,5 @@ return [
     'route_parameter_key'    => 'locale',
     'route_name_prefix'      => 'localized',
     'route_forget_parameter' => true,
-	'route_prefix_options' 	 => ['nl', 'en'],
+	'route_prefix_options' 	 => ['nl', 'de'],
 ];

--- a/config/localize.php
+++ b/config/localize.php
@@ -28,4 +28,5 @@ return [
     'route_parameter_key'    => 'locale',
     'route_name_prefix'      => 'localized',
     'route_forget_parameter' => true,
+	'route_prefix_options' 	 => ['nl', 'en'],
 ];

--- a/src/Localize.php
+++ b/src/Localize.php
@@ -1,18 +1,20 @@
 <?php
 
-
 namespace KingsCode\LaravelLocalize;
 
-use Illuminate\Contracts\Config\Repository;
+use Illuminate\Contracts\Config\Repository as Config;
 
 class Localize
 {
     /**
-     * @var \Illuminate\Contracts\Config\Repository
+     * @var Config
      */
     protected $config;
 
-    public function __construct(Repository $config)
+    /**
+     * @param Config $config
+     */
+    public function __construct(Config $config)
     {
         $this->config = $config;
     }
@@ -36,20 +38,5 @@ class Localize
     {
         $options = implode('|', array_filter($this->getLocalePrefixes() ?? []));
         return "^($options)$";
-    }
-
-    /**
-     * @param Request|null $request
-     * @return mixed
-     */
-    public function getLocaleFromRequest(Request $request = null)
-    {
-        if ($request === null) {
-            $request = request();
-        }
-
-        return $request->route()->originalParameter(
-            $this->config->get('lovalize.route_parameter_key', 'locale')
-        );
     }
 }

--- a/src/Localize.php
+++ b/src/Localize.php
@@ -1,0 +1,55 @@
+<?php
+
+
+namespace KingsCode\LaravelLocalize;
+
+use Illuminate\Contracts\Config\Repository;
+
+class Localize
+{
+    /**
+     * @var \Illuminate\Contracts\Config\Repository
+     */
+    protected $config;
+
+    public function __construct(Repository $config)
+    {
+        $this->config = $config;
+    }
+
+    /**
+     * Get all the available locale.
+     *
+     * @return array
+     */
+    public function getLocalePrefixes(): array
+    {
+        return $this->config->get('localize.route_prefix_options', []);
+    }
+
+    /**
+     * Generate regex that is used in the where to select {locale}.
+     *
+     * @return string
+     */
+    public function getRouteRegex(): string
+    {
+        $options = implode('|', array_filter($this->getLocalePrefixes() ?? []));
+        return "^($options)$";
+    }
+
+    /**
+     * @param Request|null $request
+     * @return mixed
+     */
+    public function getLocaleFromRequest(Request $request = null)
+    {
+        if ($request === null) {
+            $request = request();
+        }
+
+        return $request->route()->originalParameter(
+            $this->config->get('lovalize.route_parameter_key', 'locale')
+        );
+    }
+}

--- a/src/LocalizeServiceProvider.php
+++ b/src/LocalizeServiceProvider.php
@@ -7,6 +7,7 @@ namespace KingsCode\LaravelLocalize;
 use Illuminate\Contracts\Config\Repository;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Contracts\Routing\UrlGenerator as UrlGeneratorContract;
+use Illuminate\Foundation\Application;
 use Illuminate\Routing\Router;
 use Illuminate\Routing\UrlGenerator as BaseUrlGenerator;
 use Illuminate\Support\ServiceProvider;
@@ -45,7 +46,7 @@ class LocalizeServiceProvider extends ServiceProvider
             );
         });
 
-        $this->app->singleton(Localize::class, function ($app) {
+        $this->app->singleton(Localize::class, function (Application $app) {
             return new Localize($app->make(Repository::class));
         });
     }

--- a/src/LocalizeServiceProvider.php
+++ b/src/LocalizeServiceProvider.php
@@ -44,5 +44,9 @@ class LocalizeServiceProvider extends ServiceProvider
                 $container->make(Repository::class)
             );
         });
+
+        $this->app->singleton(Localize::class, function ($app) {
+            return new Localize($app->make(Repository::class));
+        });
     }
 }

--- a/tests/Feature/LocalizeTest.php
+++ b/tests/Feature/LocalizeTest.php
@@ -14,7 +14,7 @@ class LocalizeTest extends TestCase
      */
     protected $router;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -9,7 +9,7 @@ use Orchestra\Testbench\TestCase as Orchestra;
 
 abstract class TestCase extends Orchestra
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
     }

--- a/tests/Unit/LocalizeTest.php
+++ b/tests/Unit/LocalizeTest.php
@@ -5,13 +5,15 @@ namespace KingsCode\LaravelLocalize\Tests\Unit;
 
 use  Illuminate\Contracts\Config\Repository as Config;
 use KingsCode\LaravelLocalize\Localize;
+use KingsCode\LaravelLocalize\Tests\TestCase;
 
-class LocalizeTest
+class LocalizeTest extends TestCase
 {
     private $languages = ['nl', 'en', 'de', 'es', 'it'];
 
-    public function setUp()
+    public function setUp(): void
     {
+        parent::setUp();
         $config = $this->app->make(Config::class);
         $config->set('localize.route_prefix_options', $this->languages);
     }
@@ -26,7 +28,7 @@ class LocalizeTest
         $result = $localize->getLocalePrefixes();
         
         //Assert
-        $result->assertEqual($result, $this->languages);
+        $this->assertEquals($result, $this->languages);
     }
     
     /** @test */
@@ -40,6 +42,6 @@ class LocalizeTest
         $result = $localize->getRouteRegex();
 
         //Assert
-        $result->assertEqual($result, $expectedRegex);
+        $this->assertEquals($result, $expectedRegex);
     }
 }

--- a/tests/Unit/LocalizeTest.php
+++ b/tests/Unit/LocalizeTest.php
@@ -1,0 +1,45 @@
+<?php
+
+
+namespace KingsCode\LaravelLocalize\Tests\Unit;
+
+use  Illuminate\Contracts\Config\Repository as Config;
+use KingsCode\LaravelLocalize\Localize;
+
+class LocalizeTest
+{
+    private $languages = ['nl', 'en', 'de', 'es', 'it'];
+
+    public function setUp()
+    {
+        $config = $this->app->make(Config::class);
+        $config->set('localize.route_prefix_options', $this->languages);
+    }
+    
+    /** @test */
+    public function get_locale_prefixes_returns_correct_array()
+    {
+        //Arrange
+        $localize = $this->app->make(Localize::class);
+        
+        //Act
+        $result = $localize->getLocalePrefixes();
+        
+        //Assert
+        $result->assertEqual($result, $this->languages);
+    }
+    
+    /** @test */
+    public function get_route_regex_returns_correct_regex()
+    {
+        //Arrange
+        $localize = $this->app->make(Localize::class);
+        $expectedRegex = '^(nl|en|de|es|it)$';
+
+        //Act
+        $result = $localize->getRouteRegex();
+
+        //Assert
+        $result->assertEqual($result, $expectedRegex);
+    }
+}


### PR DESCRIPTION
After a talk with @koenhoeijmakers on slack, we implemented this package is one of our projects. We encountered a problem with our catch-all route because of the "normal" being registered first. To fix this we switched the route registration so the locale routes will be registered first but then the issue appears that {locale} will catch everything. That is why we added a where statement on the registration so the {locale} will only allow the language tags you specified in the config.